### PR TITLE
Update kubernetes yaml to remove depricated api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cron-connector.exe
+.idea/

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Works with both armd64 and armhf (Raspberry Pi).
 
 1. For Docker Swarm: 
 ```
-curl -s https://raw.githubusercontent.com/zeerorg/cron-connector/master/yaml/docker-compose.yml | docker stack deploy func -c -
+curl -s https://raw.githubusercontent.com/openfaas-incubator/cron-connector/master/yaml/docker-compose.yml | docker stack deploy func -c -
 ```
 
 2. For Kubernetes:
 ```
-curl -s https://raw.githubusercontent.com/zeerorg/cron-connector/master/yaml/kubernetes/connector-dep.yml | kubectl create --namespace openfaas -f -
+curl -s https://raw.githubusercontent.com/openfaas-incubator/cron-connector/master/yaml/kubernetes/connector-dep.yml | kubectl create --namespace openfaas -f -
 ```
 
 ## Adding function

--- a/chart/cron-connector/templates/deployment.yaml
+++ b/chart/cron-connector/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -16,6 +16,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app: {{ templare "connector.name . }}
       name: {{ template "connector.name" . }}
       component: cron-connector
   template:

--- a/yaml/kubernetes/connector-dep.yml
+++ b/yaml/kubernetes/connector-dep.yml
@@ -1,5 +1,5 @@
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -8,6 +8,9 @@ metadata:
   name: sample-connector
   namespace: openfaas
 spec:
+  selector:
+    matchLabels:
+      app: connector
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Change extensions/ to apps/v1 as extensions are deprecated
This also updates the README to point at the openfass-incubator's raw yamls.
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

Closes #1 

## Testing

This has been tested on K8s 1.16 (Digital ocean) by running kubectl apply -f path/to/yaml.yaml