### PR TITLE
Added option for async function invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ The function should have 2 annotations:
 
 1. `topic` annotation should be `cron-function`.
 2. `schedule` annotation should be the cron schedule on which to invoke function
+3. `async` annotation defines async invocation (`true` or `false`) - default `false`
 
 For example, we may have a function "nodeinfo" which we want to invoke every 5 minutes:
 
 Deploy via the CLI:
 
 ```
-faas-cli store deploy nodeinfo --annotation schedule="*/5 * * * *" --annotation topic=cron-function
+faas-cli store deploy nodeinfo --annotation schedule="*/5 * * * *" --annotation topic=cron-function -annotation async="true"
 ```
 
 Or via `stack.yml`:
@@ -64,6 +65,7 @@ functions:
     annotations:
       topic: cron-function
       schedule: "*/5 * * * *"
+      async: "true"
 ```
 
 You can learn how to create and test the [Cron syntax here](https://crontab.guru/every-5-minutes).

--- a/main_test.go
+++ b/main_test.go
@@ -68,3 +68,29 @@ func TestNamespaceFuncs(t *testing.T) {
 		t.Error("function should be left as it is")
 	}
 }
+
+func TestAsyncFuncs(t *testing.T) {
+	newCronFunctions := make(cfunction.CronFunctions, 3)
+	defaultReq := ptypes.FunctionStatus{}
+	newCronFunctions[0] = cfunction.CronFunction{FuncData: defaultReq, Name: "test_async_one", Namespace: "openfaas-fn", Schedule: "* * * * *"}
+	newCronFunctions[1] = cfunction.CronFunction{FuncData: defaultReq, Name: "test_async_two", Namespace: "openfaas-fn", Schedule: "* * * * *", Async: true}
+	newCronFunctions[2] = cfunction.CronFunction{FuncData: defaultReq, Name: "test_async_three", Namespace: "openfaas-fn", Schedule: "* * * * *", Async: true}
+
+	oldFuncs := make(cfunction.ScheduledFunctions, 3)
+	oldFuncs[0] = cfunction.ScheduledFunction{Function: cfunction.CronFunction{FuncData: defaultReq, Name: "test_async_one", Namespace: "openfaas-fn", Schedule: "* * * * *"}, ID: 0}
+	oldFuncs[1] = cfunction.ScheduledFunction{Function: cfunction.CronFunction{FuncData: defaultReq, Name: "test_async_two", Namespace: "openfaas-fn", Schedule: "* * * * *", Async: false}, ID: 0}
+	oldFuncs[1] = cfunction.ScheduledFunction{Function: cfunction.CronFunction{FuncData: defaultReq, Name: "test_async_three", Namespace: "openfaas-fn", Schedule: "* * * * *", Async: true}, ID: 0}
+
+	addFuncs, deleteFuncs := GetNewAndDeleteFuncs(newCronFunctions, oldFuncs, "openfaas-fn")
+	if !deleteFuncs.Contains(&oldFuncs[1].Function) && !addFuncs.Contains(&newCronFunctions[1]) {
+		t.Error("function will not be updated")
+	}
+
+	if addFuncs.Contains(&newCronFunctions[0]) || deleteFuncs.Contains(&newCronFunctions[0]) {
+		t.Error("function should be left as it is")
+	}
+
+	if addFuncs.Contains(&newCronFunctions[2]) || deleteFuncs.Contains(&newCronFunctions[2]) {
+		t.Error("function should be left as it is")
+	}
+}


### PR DESCRIPTION
Hi @zeerorg and @alexellis,

I've added the ability to deploy functions using cron-connector with an additional annotation, "async", with a value of either "true" or "false", which will invoke functions using the gateway's asynchronous function path `/async-function/` when set to "true".
Existing deployments shouldn't be affected, since the connector will assume a default value of "false" if the "async" annotation is missing.

Please let me know if I missed anything.

Thanks :smile: 

---

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) #11
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.