### PR TITLE
Add async endpoint support

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"testing"
 
+	"github.com/openfaas/connector-sdk/types"
 	cfunction "github.com/openfaas/cron-connector/types"
 	ptypes "github.com/openfaas/faas-provider/types"
 )
@@ -67,4 +68,36 @@ func TestNamespaceFuncs(t *testing.T) {
 	if addFuncs.Contains(&newCronFunctions[0]) || deleteFuncs.Contains(&newCronFunctions[0]) {
 		t.Error("function should be left as it is")
 	}
+}
+
+func TestGatewayRoute_Async(t *testing.T) {
+	testscases := []struct {
+		GatewayURL              string
+		ExpectedGatewayURL      string
+		AsyncFunctionInvocation bool
+	}{
+		{
+			GatewayURL:              "http://localhost:8080",
+			AsyncFunctionInvocation: true,
+			ExpectedGatewayURL:      "http://localhost:8080/async-function",
+		},
+		{
+			GatewayURL:              "http://localhost:8080",
+			AsyncFunctionInvocation: false,
+			ExpectedGatewayURL:      "http://localhost:8080/function",
+		},
+	}
+
+	for _, test := range testscases {
+		config := &types.ControllerConfig{
+			GatewayURL:              test.GatewayURL,
+			AsyncFunctionInvocation: test.AsyncFunctionInvocation,
+		}
+
+		val := gatewayRoute(config)
+		if val != test.ExpectedGatewayURL {
+			t.Errorf("expected: %s, got: %s", test.ExpectedGatewayURL, val)
+		}
+	}
+
 }

--- a/types/cron_function.go
+++ b/types/cron_function.go
@@ -66,7 +66,7 @@ func ToCronFunction(f ptypes.FunctionStatus, namespace string, topic string) (Cr
 
 // InvokeFunction Invokes the cron function
 func (c CronFunction) InvokeFunction(i *types.Invoker) (*[]byte, error) {
-	gwURL := fmt.Sprintf("%s/function/%s.%s", i.GatewayURL, c.Name, c.Namespace)
+	gwURL := fmt.Sprintf("%s/%s.%s", i.GatewayURL, c.Name, c.Namespace)
 	reader := bytes.NewReader(make([]byte, 0))
 	httpReq, _ := http.NewRequest(http.MethodPost, gwURL, reader)
 


### PR DESCRIPTION
This commit adds async endpoint support to cron connector which can be enabled
using `async_invocation` environment variable

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

#11

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my local system 
```
k logs cron-connector-79d479b777-bvh7w -n openfaas -f
2021/03/20 17:20:54 Version: 43da735bc8f99800a52718a3e5ac31c4884349b7	Commit: dev
2021/03/20 17:20:54 Gateway URL:  http://gateway.openfaas:8080
2021/03/20 17:20:54 Async Invocation:  true
2021/03/20 17:21:04 added function nodeinfo in openfaas-fn
2021/03/20 17:25:00 Executed function: nodeinfo (ns=openfaas-fn)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
