### PR TITLE
Warn, instead of exiting on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,13 +122,15 @@ func startFunctionProbe(interval time.Duration, probeTimeout time.Duration, topi
 
 		namespaces, err := sdkClient.ListNamespaces(ctx)
 		if err != nil {
-			return fmt.Errorf("can't list namespaces: %w", err)
+			log.Printf("error listing namespaces: %s", err)
+			continue
 		}
 
 		for _, namespace := range namespaces {
 			functions, err := sdkClient.ListFunctions(ctx, namespace)
 			if err != nil {
-				return fmt.Errorf("can't list functions: %w", err)
+				log.Printf("error listing functions in %s: %s", namespace, err)
+				continue
 			}
 
 			newCronFunctions := requestsToCronFunctions(functions, namespace, topic)
@@ -147,7 +149,8 @@ func startFunctionProbe(interval time.Duration, probeTimeout time.Duration, topi
 			for _, function := range addFuncs {
 				f, err := cronScheduler.AddCronFunction(function, invoker)
 				if err != nil {
-					return fmt.Errorf("can't add function: %s, %w", function.String(), err)
+					log.Printf("can't add function: %s, %s", function.String(), err)
+					continue
 				}
 
 				newScheduledFuncs = append(newScheduledFuncs, f)


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Warn, instead of exiting on error

## Motivation and Context

Fixes: https://github.com/zeerorg/cron-connector/issues/25

## How Has This Been Tested?

Testing pending, it should stop the code from hanging when the list functions endpoint returns an error though.