### PR TITLE
fix cron connector for no auth

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/openfaas/connector-sdk/types"
@@ -40,6 +41,16 @@ func getControllerConfig() (*types.ControllerConfig, error) {
 		rebuildInterval = d
 	}
 
+	var basicAuth bool
+	if val, exists := os.LookupEnv("basic_auth"); exists {
+		a, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, err
+		}
+
+		basicAuth = a
+	}
+
 	return &types.ControllerConfig{
 		RebuildInterval:         rebuildInterval,
 		GatewayURL:              gURL,
@@ -48,5 +59,6 @@ func getControllerConfig() (*types.ControllerConfig, error) {
 		PrintResponse:           true,
 		PrintResponseBody:       printResponseBody,
 		PrintRequestBody:        false,
+		BasicAuth:               basicAuth,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -98,13 +98,27 @@ func (auth *BasicAuth) Set(req *http.Request) error {
 	return nil
 }
 
+// NoAuth auth to when basic auth is disabled
+type NoAuth struct {
+}
+
+// Set authorization header or request
+func (auth *NoAuth) Set(req *http.Request) error {
+	return nil
+}
+
 func startFunctionProbe(interval time.Duration, probeTimeout time.Duration, topic string, c *types.ControllerConfig, cronScheduler *crontypes.Scheduler, invoker *types.Invoker) error {
 	runningFuncs := make(crontypes.ScheduledFunctions, 0)
 
-	creds := types.GetCredentials()
-	auth := &BasicAuth{
-		Username: creds.User,
-		Password: creds.Password,
+	var auth sdk.ClientAuth
+	if c.BasicAuth {
+		creds := types.GetCredentials()
+		auth = &BasicAuth{
+			Username: creds.User,
+			Password: creds.Password,
+		}
+	} else {
+		auth = &NoAuth{}
 	}
 
 	sdkClient, err := sdk.NewClient(auth, c.GatewayURL, nil, &probeTimeout)


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Fix cron connector to work without basic auth
## Description
<!--- Describe your changes in detail -->
Fix cron connector to work without basic auth
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

Closes #22 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Build docker image in local
```
docker build .
docker tag 7ac5265766e0 ghcr.io/openfaas/cron-connector:local
```

### Test with `basic_auth=false`

1. Create Cluster and deploy openfaas
```
kind create cluster --name faas
arkade install openfaas --basic-auth=false
```

2. Load local image and deploy cron-connector
```
kind load docker-image ghcr.io/openfaas/cron-connector:local --name faas
arkade install cron-connector --set basicAuth=false --set image=ghcr.io/openfaas/cron-connector:local
```

3. Deploy function and check logs
```
faas-cli store deploy sleep --annotation topic=cron-function --annotation schedule="*/1 * * * *"
```

```
2022/09/02 15:16:13 Version: 53b0fc79837b153e8b1bb5117b88f311c5d70274    Commit: dev                                                                                                                            
2022/09/02 15:16:13 Gateway URL: http://gateway.openfaas:8080                                                                                                                                                   
2022/09/02 15:16:13 Async Invocation: false                                                                                                                                                                     
2022/09/02 15:16:13 Rebuild interval: 10s    Rebuild timeout: 5s                                                                                                                                                
2022/09/02 15:19:23 Added: sleep.openfaas-fn [*/1 * * * *]
```

4. Destroy cluster
```
kind delete cluster --name faas
```

#### Test with `basic_auth=true`

1. Create Cluster and deploy openfaas
```
kind create cluster --name faas
arkade install openfaas
kubectl port-forward -n openfaas svc/gateway 8080:8080 &
PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
echo -n $PASSWORD | faas-cli login --username admin --password-stdin
```

2. Load local image and deploy cron-connector
```
kind load docker-image ghcr.io/openfaas/cron-connector:local --name faas
arkade install cron-connector --set image=ghcr.io/openfaas/cron-connector:local
```

3. Deploy function and check logs
```
faas-cli store deploy sleep --annotation topic=cron-function --annotation schedule="*/1 * * * *"
```

```
2022/09/02 15:28:59 Version: 53b0fc79837b153e8b1bb5117b88f311c5d70274    Commit: dev                                                                                                                            
2022/09/02 15:28:59 Gateway URL: http://gateway.openfaas:8080                                                                                                                                                   
2022/09/02 15:28:59 Async Invocation: false                                                                                                                                                                     
2022/09/02 15:28:59 Rebuild interval: 30s    Rebuild timeout: 5s                                                                                                                                                
2022/09/02 15:30:59 Added: sleep.openfaas-fn [*/1 * * * *]                                                                                                                                                      
2022/09/02 15:31:00 Invoking: sleep.openfaas-fn [*/1 * * * *]                                                                                                                                                   
2022/09/02 15:31:02 Response: sleep [200] (2.01s)
```

4. Destroy cluster
```
kind delete cluster --name faas
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
